### PR TITLE
Add non-follower detection feature

### DIFF
--- a/Instagram_bot.py
+++ b/Instagram_bot.py
@@ -37,9 +37,23 @@ class Instagram:
         self.browser.find_element_by_class_name("k9GMp").find_element_by_tag_name("a").click()
         time.sleep(2)
         followers = self.browser.find_element_by_class_name("PZuss").find_elements_by_tag_name("li")
+        result = []
         for user in followers:
             link = user.find_element_by_tag_name("a").get_attribute("href")
+            result.append(link)
             print(link)
+        return result
+
+    def getFollowing(self):
+        self.browser.get(f"https://www.instagram.com/{self.username}/following/")
+        time.sleep(2)
+        following = self.browser.find_element_by_class_name("PZuss").find_elements_by_tag_name("li")
+        result = []
+        for user in following:
+            link = user.find_element_by_tag_name("a").get_attribute("href")
+            result.append(link)
+            print(link)
+        return result
 
 
     def followUser(self,username):
@@ -61,6 +75,13 @@ class Instagram:
             self.browser.find_element_by_xpath("//button[contains(text(), 'unfollow')]" \
                 "| //button[contains(text(), 'Takibi bırak')]").click()
 
+    def getNonFollowers(self):
+        followers = set(self.getFollowers())
+        followings = set(self.getFollowing())
+        non_followers = followings - followers
+        for user in non_followers:
+            print(user)
+
     def __del__(self):
         time.sleep(10)
         self.browser.close()
@@ -68,5 +89,5 @@ class Instagram:
 app = Instagram(username,password)
 
 app.signIn()
-app.getFollowers()
+app.getNonFollowers()
 

--- a/README.md
+++ b/README.md
@@ -9,4 +9,5 @@ Eklenen Özellikler
 ------------------
 * `followUser` fonksiyonu ile belirtilen bir kullanıcıyı takip edebilirsiniz.
 * `unFollowers` fonksiyonu ile takip ettiğiniz bir kullanıcıyı bırakabilirsiniz.
+* `getNonFollowers` fonksiyonu ile sizi takip etmeyen kullanıcıları listeleyebilirsiniz.
 


### PR DESCRIPTION
## Summary
- capture links from followers and following
- add `getFollowing` and `getNonFollowers`
- run `getNonFollowers` after login
- document new capability

## Testing
- `python -m py_compile Instagram_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_684ad9da3394832a9e7b456d84faa0ab